### PR TITLE
remove old client if the same client id is used in new connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:10.16
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+
+      # run tests!
+      - run: yarn test
+
+

--- a/lib/ClientManager.js
+++ b/lib/ClientManager.js
@@ -32,9 +32,10 @@ class ClientManager {
         const clients = this.clients;
         const stats = this.stats;
 
-        // can't ask for id already is use
+        // if id already is use, close current one
         if (clients[id]) {
-            id = hri.random();
+            this.debug('found client %s in used, removing it', id);
+            clients[id].close();
         }
 
         const maxSockets = this.opt.max_tcp_sockets;

--- a/lib/ClientManager.test.js
+++ b/lib/ClientManager.test.js
@@ -23,13 +23,15 @@ describe('ClientManager', () => {
         manager.removeClient('foobar');
     });
 
-    it('should create a new client with random id if previous exists', async () => {
+    it('should delete old client if client id already exists', async () => {
         const manager = new ClientManager();
         const clientA = await manager.newClient('foobar');
-        const clientB = await manager.newClient('foobar');
         assert(clientA.id, 'foobar');
+        assert(manager.hasClient(clientA.id));
+        const clientB = await manager.newClient('foobar');
+        assert(clientB.id, 'foobar');
         assert(manager.hasClient(clientB.id));
-        assert(clientB.id != clientA.id);
+        assert(clientB.id == clientA.id);
         manager.removeClient(clientB.id);
         manager.removeClient('foobar');
     });


### PR DESCRIPTION
Each client id at Appfolio is mostly unique per user so if the same value is repeated, that means a different process from same user